### PR TITLE
Fix Premature Deadlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 coverage
 .DS_Store
 .idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "illuminate/support": "^5.6",
-        "nesbot/carbon": "^1.31"
+        "php": "^8.0",
+        "nesbot/carbon": "^2.56",
+        "illuminate/support": "^8.81"
     },
     "require-dev": {
-        "larapack/dd": "^1.0",
-        "phpunit/phpunit": "^7.0"
+        "larapack/dd": "^1.1",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -36,7 +36,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true

--- a/src/DeadlineCalculator.php
+++ b/src/DeadlineCalculator.php
@@ -49,15 +49,14 @@ class DeadlineCalculator
     {
         $deadline = $this->startFrom;
 
+        // If the calculation occurs before the start of the operating hours or on holidays,
+        // we bring the time to the operating hours.
+        $this->toOperatingHours($deadline);
+
         for ($i = 0; $i < $this->tatInHours; $i++) {
             $deadline->addHour();
 
-            while (
-                $this->isHoliday($deadline) or
-                $this->isBeyondOperatingHours($deadline)
-            ) {
-                $deadline->addHour();
-            }
+            $this->toOperatingHours($deadline);
         }
 
         return $deadline->format('Y-m-d H:i:s');
@@ -94,6 +93,24 @@ class DeadlineCalculator
         return $this;
     }
 
+    /**
+     * Reschedules a deadline to the operating hours.
+     *
+     * @param Carbon $deadline
+     * @return Carbon
+     */
+    protected function toOperatingHours($deadline)
+    {
+        while (
+            $this->isHoliday($deadline) or
+            $this->isBeyondOperatingHours($deadline)
+        ) {
+            $deadline->addHour();
+        }
+
+        return $deadline;
+    }
+
     protected function isHoliday(Carbon $day)
     {
         return $this->holidays->has($day->format('Y-m-d'));
@@ -115,11 +132,7 @@ class DeadlineCalculator
 
         $deadline = $deadline->format('H:i:s');
 
-        if (($deadline >= $end) or ($deadline < $start)) {
-            return true;
-        }
-
-        return false;
+        return ($deadline >= $end) or ($deadline < $start);
     }
 
     public function sunday($start, $end)
@@ -200,5 +213,4 @@ class DeadlineCalculator
             'end' => $end,
         ];
     }
-
 }

--- a/tests/OperatingHoursTest.php
+++ b/tests/OperatingHoursTest.php
@@ -3,7 +3,6 @@
 namespace Bzarzuela\DeadlineCalculator\Tests;
 
 use Bzarzuela\DeadlineCalculator\DeadlineCalculator;
-use Carbon\Carbon;
 use PHPUnit\Framework\TestCase;
 
 class OperatingHoursTest extends TestCase
@@ -21,7 +20,19 @@ class OperatingHoursTest extends TestCase
     }
 
     /** @test */
-    function deadlines_on_a_friday_afternoon_will_be_started_on_monday()
+    function deadlines_at_night_will_be_started_on_operating_hours()
+    {
+        $calculator = new DeadlineCalculator();
+
+        $calculator->startFrom('2018-06-28 06:00:00')
+            ->operatingHours('09:00:00', '18:00:00')
+            ->tatInHours(1);
+
+        $this->assertEquals('2018-06-28 10:00:00', $calculator->deadline());
+    }
+
+    /** @test */
+    function deadlines_at_night_will_start_at_operating_hours()
     {
         $calculator = new DeadlineCalculator();
 


### PR DESCRIPTION
If the calculation occurs before the start of operating hours or on holidays, we lose 1 hour, because first it adds 1 hour, and then transfers the time to operating hours.

for example: 
start from: `2018-06-28 06:00:00`,
operating hours: `09:00:00-18:00:00`
tat in hours: `1`,
expected: `2018-06-28 10:00:00`
actual: `2018-06-28 09:00:00`

